### PR TITLE
`jarMove`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,8 +95,8 @@ task deploy(type: Jar){
 task moveDesktop doFirst{
     exec{
         workingDir "$buildDir"
+        println "Moving ${project.archivesBaseName} to the mods folder..."
         if(System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("windows")){
-            println "Yeeting ${project.archivesBaseName} to the shadow realm..."
             commandLine("cmd", "/C", "move", "/Y", "libs\\${project.archivesBaseName}Desktop.jar", "%userprofile%\\AppData\\Roaming\\Mindustry\\mods")
         }else{
             println "This task was made only for Windows. If you are a mac user, please PR the proper command to move the compiled mod to the mods folder."

--- a/build.gradle
+++ b/build.gradle
@@ -91,3 +91,17 @@ task deploy(type: Jar){
         }
     }
 }
+
+task moveDesktop doFirst{
+    exec{
+        workingDir "$buildDir"
+        if(System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("windows")){
+            println "Yeeting ${project.archivesBaseName} to the shadow realm..."
+            commandLine("cmd", "/C", "move", "/Y", "libs\\${project.archivesBaseName}Desktop.jar", "%userprofile%\\AppData\\Roaming\\Mindustry\\mods")
+        }else{
+            println "This task was made only for Windows. If you are a mac user, please PR the proper command to move the compiled mod to the mods folder."
+        }
+    }
+}
+
+task jarMove dependsOn "jar", "moveDesktop"


### PR DESCRIPTION
Adds `jarMove`, which I first created for [PM](https://github.com/MEEPofFaith/prog-mats-java/blob/30250eba22ff95624d8640024e895e17f400efb2/build.gradle#L92).
Compiles the mod (desktop) and moves the compiles jar to the mods folder.

Things that need fixing:
 - Missing functionality for Mac. I don't know how to invoke Mac's console, nor do I know the file movement syntax. Someone pr this for me.
 - Since `jar` does not create a new jar if no changes were made, running `jarMove` twice in a row without making any changes will result in a fail because `moveDesktop` cannot find the jar. (Not a problem, just a little annoyance.) Dunno how to make it just not run if no changes are detected.