### PR TITLE
Update build.gradle to "fix the directory management for multi-project workspaces"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ jar{
         configurations.runtimeClasspath.collect{ it.isDirectory() ? it : zipTree(it) }
     }
 
-    from(rootDir){
+    from(projectDir){
         include "mod.hjson"
     }
 


### PR DESCRIPTION
**Build scripts are broken on workspaces where the project is not in the root folder. This causes the resources to not be packed into the outputted jar.**

This can be solved bu changing _rootDir_ to _projectDir_ on [MindustryJavaModTemplate/build.gradle](https://github.com/Anuken/MindustryJavaModTemplate/blob/dc6736de09df783a733fa5f696c5195ca56f17ca/build.gradle#L78)