### PR TITLE
Update commitTest.yml

### DIFF
--- a/.github/workflows/commitTest.yml
+++ b/.github/workflows/commitTest.yml
@@ -7,14 +7,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up PATH
       run: |
         echo "${ANDROID_HOME}/build-tools/34.0.0" >> $GITHUB_PATH
     - name: Set up JDK 17
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
-        java-version: 17
+        java-version: '17'
+        distribution: 'temurin'
     - name: Build mod jar
       run: |
         chmod +x ./gradlew


### PR DESCRIPTION
Updating actions to the latest versions: checkout@v4 and setup-java@v4. The older versions rely on Node.js 20, which has been deprecated and will be replaced by Node.js 24 starting June 16, 2026.